### PR TITLE
Swap deprecated `queue` with `enqueue`.

### DIFF
--- a/queues/que.rb
+++ b/queues/que.rb
@@ -12,7 +12,7 @@ SQL
 class QuePerpetualJob < Que::Job
   def run
     Que.execute "begin"
-    self.class.queue
+    self.class.enqueue
     destroy
     Que.execute "commit"
   end


### PR DESCRIPTION
The `queue` call was spitting out lots of deprecation warnings, this cuts down the verbosity.
